### PR TITLE
Update ekir_special_terraform.txt

### DIFF
--- a/common/terraform/ekir_special_terraform.txt
+++ b/common/terraform/ekir_special_terraform.txt
@@ -1,129 +1,147 @@
-# Terraform go brrr
-@gaiaCost = 7500
-@gaiaTime = 3600
+# ====================================================================
+# Terraforming Configuration: "Terraform go brrr"
+#
+# Macros for cost and time placeholders
+# ====================================================================
+@gaiaCost        = 7500
+@gaiaTime        = 3600
 
-@highestCost = 12500
-@highestTime = 9000
+@highestCost     = 12500
+@highestTime     = 9000
 
-@machineCost = 10000
-@machineTime = 7200
+@machineCost     = 10000
+@machineTime     = 7200
 
-@hiveCost = 10000
-@hiveTime = 7200
+@hiveCost        = 10000
+@hiveTime        = 7200
 
-@lClusterCost = 1000
+@lClusterCost    = 1000
 
+
+# ====================================================================
+# Terraform link from "pc_relic" to "pc_machine"
+# Requires "ap_machine_worlds" ascension perk and checks various conditions
+# ====================================================================
 terraform_link = {
-	to = "pc_machine"
-	from = "pc_relic"
+  from = "pc_relic"
+  to   = "pc_machine"
 
-	resources = {
-		category = terraforming
+  resources = {
+    category = terraforming
+    cost = {
+      energy = @machineCost
+    }
+  }
 
-		cost = {
-			energy = @machineCost
-		}
-	}
+  duration = @machineTime
 
-	duration = @machineTime
+  potential = {
+    exists = owner
+    has_ascension_perk = ap_machine_worlds
+  }
 
-	potential = {
-		exists = owner
-		has_ascension_perk = ap_machine_worlds
-	}
+  condition = {
+    from = {
+      OR = {
+        is_owned_by = root
+        NOT = { has_modifier = "holy_planet" }
+      }
+    }
+  }
 
-	condition = {
-		from = {
-			OR = {
-				is_owned_by = root
-				NOT = { has_modifier = "holy_planet" }
-			}
-		}
-	}
-
-	ai_weight = {
-		weight = 10
-		modifier = {
-			factor = 0
-			from = {
-				any_owned_species = {
-					NOR = {
-						has_trait = trait_machine_unit
-						has_trait = trait_mechanical
-					}
-					is_sapient = yes
-				}
-			}
-		}
-	}
+  ai_weight = {
+    weight = 10
+    modifier = {
+      factor = 0
+      from = {
+        any_owned_species = {
+          NOR = {
+            has_trait = trait_machine_unit
+            has_trait = trait_mechanical
+          }
+          is_sapient = yes
+        }
+      }
+    }
+  }
 }
+
+
+# ====================================================================
+# Terraform link from "pc_relic" to "pc_hive"
+# Requires "ap_hive_worlds" ascension perk and checks various conditions
+# ====================================================================
 terraform_link = {
-	to = "pc_hive"
-	from = "pc_relic"
+  from = "pc_relic"
+  to   = "pc_hive"
 
-	resources = {
-		category = terraforming
+  resources = {
+    category = terraforming
+    cost = {
+      energy = @hiveCost
+    }
+  }
 
-		cost = {
-			energy = @hiveCost
-		}
-	}
+  duration = @hiveTime
 
-	duration = @hiveTime
+  potential = {
+    exists = owner
+    has_ascension_perk = ap_hive_worlds
+  }
 
-	potential = {
-		exists = owner
-		has_ascension_perk = ap_hive_worlds
-	}
+  condition = {
+    from = {
+      OR = {
+        is_owned_by = root
+        NOT = { has_modifier = "holy_planet" }
+      }
+    }
+  }
 
-	condition = {
-		from = {
-			OR = {
-				is_owned_by = root
-				NOT = { has_modifier = "holy_planet" }
-			}
-		}
-	}
-
-	ai_weight = {
-		weight = 10
-		modifier = {
-			factor = 0
-			NOT = { has_origin = origin_necrophage }
-			from = {
-				any_owned_species = {
-					NOT = { has_trait = trait_hive_mind }
-					is_sapient = yes
-				}
-			}
-		}
-	}
+  ai_weight = {
+    weight = 10
+    modifier = {
+      factor = 0
+      NOT = { has_origin = origin_necrophage }
+      from = {
+        any_owned_species = {
+          NOT = { has_trait = trait_hive_mind }
+          is_sapient = yes
+        }
+      }
+    }
+  }
 }
+
+
+# ====================================================================
+# Terraform link from "pc_relic" to "pc_gaia"
+# Requires "ap_world_shaper" ascension perk OR a special planet flag
+# ====================================================================
 terraform_link = {
-	from = "pc_relic"
-	to = "pc_gaia"
+  from = "pc_relic"
+  to   = "pc_gaia"
 
-	resources = {
-		category = terraforming
+  resources = {
+    category = terraforming
+    cost = {
+      energy = @gaiaCost
+    }
+  }
 
-		cost = {
-			energy = @gaiaCost
-		}
-	}
+  duration = @gaiaTime
 
-	duration = @gaiaTime
+  potential = {
+    OR = {
+      from = { has_planet_flag = terraform_nucleus_transfixed }
+      AND = {
+        exists = owner
+        has_ascension_perk = "ap_world_shaper"
+      }
+    }
+  }
 
-	potential = {
-		OR = {
-			from = { has_planet_flag = terraform_nucleus_transfixed }
-			AND = {
-				exists = owner
-				has_ascension_perk = "ap_world_shaper"
-			}
-		}
-	}
-
-	ai_weight = {
-		weight = 1
-	}
+  ai_weight = {
+    weight = 1
+  }
 }


### PR DESCRIPTION
Below is a cleaned-up, enhanced, and commented version of your Stellaris mod code related to terraforming. The improvements focus on:

Consistent Formatting & Indentation

Each terraform_link block is clearly separated.
Key properties (to, from, resources, duration, potential, condition, etc.) are properly aligned. Optional Comments

Provided some short clarifications for each section (resources, potential, condition, etc.). Logical Grouping & Readability

All cost/time macros (@gaiaCost, @machineCost, etc.) appear at the top. Each terraforming definition is organized for easy scanning. No Logic Changes

The placeholders, references, and condition checks remain the same to avoid breaking the mod’s function. If you want to unify repeated logic (e.g., condition blocks) or rename placeholders, you can adapt further. Feel free to adapt or remove any comments or reorder sections based on your project’s style.

Notes & Possible Extensions
Macros: These placeholders (@gaiaCost, @machineCost, etc.) help unify repeated numbers. If you want different costs/times for more terraforming cases, add them consistently at the top. Conditions: Each condition block references ownership, ascension perks, and planet modifiers. You can easily adapt or extend these. AI Weight: The ai_weight logic uses modifiers to prevent or encourage the AI from using certain transformations. You can tweak weight and factor for balancing. This structured approach should make your terraforming definitions more readable, easier to maintain, and simple to expand as your mod evolves.